### PR TITLE
Summarize thread titles

### DIFF
--- a/ChatApp/Components/Layout/MainLayout.razor.css
+++ b/ChatApp/Components/Layout/MainLayout.razor.css
@@ -53,6 +53,7 @@ main {
 
     .sidebar {
         width: 250px;
+        min-width: 25ch;
         height: 100vh;
         position: sticky;
         top: 0;

--- a/ChatApp/Components/Layout/NavMenu.razor
+++ b/ChatApp/Components/Layout/NavMenu.razor
@@ -19,7 +19,8 @@
             {
                 <div class="nav-item px-3">
                     <NavLink class="nav-link" href="@($"/chat/{thread.Id}")">
-                        <span class="bi bi-chat-text-fill-nav-menu" aria-hidden="true"></span> @thread.Title
+                        <span class="bi bi-chat-text-fill-nav-menu" aria-hidden="true"></span>
+                        <span class="thread-title">@thread.Title</span>
                     </NavLink>
                 </div>
             }

--- a/ChatApp/Components/Layout/NavMenu.razor.css
+++ b/ChatApp/Components/Layout/NavMenu.razor.css
@@ -53,7 +53,7 @@
         padding-bottom: 1rem;
     }
 
-    .nav-item ::deep .nav-link {
+.nav-item ::deep .nav-link {
         color: #d7d7d7;
         background: none;
         border: none;
@@ -63,6 +63,13 @@
         align-items: center;
         line-height: 3rem;
         width: 100%;
+    }
+
+    .nav-item ::deep .thread-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        flex: 1;
     }
 
 .nav-item ::deep a.active {

--- a/ChatApp/Components/Pages/Chat.razor
+++ b/ChatApp/Components/Pages/Chat.razor
@@ -35,7 +35,7 @@
 
     private List<ChatMessage> Messages = new();
     private string UserMessage = string.Empty;
-    private string SelectedModel = "gpt-35-turbo";
+    private string SelectedModel = "gpt-4o";
     private string[] Models = ["gpt-35-turbo", "gpt-4o"];
     private string? UserId;
 

--- a/ChatApp/Components/Pages/Chat.razor
+++ b/ChatApp/Components/Pages/Chat.razor
@@ -36,7 +36,7 @@
     private List<ChatMessage> Messages = new();
     private string UserMessage = string.Empty;
     private string SelectedModel = "gpt-35-turbo";
-    private string[] Models = ["gpt-35-turbo", "gpt-4"];
+    private string[] Models = ["gpt-35-turbo", "gpt-4o"];
     private string? UserId;
 
     protected override async Task OnInitializedAsync()

--- a/ChatApp/Components/Pages/Chat.razor.css
+++ b/ChatApp/Components/Pages/Chat.razor.css
@@ -1,0 +1,9 @@
+.chat-window {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.chat-message {
+    white-space: pre-wrap;
+}

--- a/ChatApp/Services/AzureOpenAIChatService.cs
+++ b/ChatApp/Services/AzureOpenAIChatService.cs
@@ -46,7 +46,7 @@ namespace ChatApp.Services
             {
                 messages = new[]
                 {
-                    new { role = "system", content = "Summarize the following text in a short phrase suitable as a title. Do not under any circumstances exceed 20 characters" },
+                    new { role = "system", content = "Summarize the following text in under 20 characters." },
                     new { role = "user", content = text }
                 }
             };
@@ -55,8 +55,12 @@ namespace ChatApp.Services
             response.EnsureSuccessStatusCode();
             using var stream = await response.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
-            var summary = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
-            return summary ?? text;
+            var summary = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString() ?? text;
+            if (summary.Length > 20)
+            {
+                summary = summary.Substring(0, 20);
+            }
+            return summary;
         }
     }
 }

--- a/ChatApp/Services/AzureOpenAIChatService.cs
+++ b/ChatApp/Services/AzureOpenAIChatService.cs
@@ -39,14 +39,14 @@ namespace ChatApp.Services
 
         public async Task<string> SummarizeAsync(string text)
         {
-            var url = $"{_endpoint}/openai/deployments/gpt-35-turbo/chat/completions?api-version=2023-07-01-preview";
+            var url = $"{_endpoint}/openai/deployments/gpt-4o/chat/completions?api-version=2023-07-01-preview";
             using var request = new HttpRequestMessage(HttpMethod.Post, url);
             request.Headers.Add("api-key", _key);
             var payload = new
             {
                 messages = new[]
                 {
-                    new { role = "system", content = "Summarize the following text in a short phrase suitable as a title." },
+                    new { role = "system", content = "Summarize the following text in a short phrase suitable as a title. Do not under any circumstances exceed 20 characters" },
                     new { role = "user", content = text }
                 }
             };

--- a/ChatApp/Services/BlobChatHistoryService.cs
+++ b/ChatApp/Services/BlobChatHistoryService.cs
@@ -51,7 +51,7 @@ namespace ChatApp.Services
             bool changed = false;
             for (int i = 0; i < threads.Count; i++)
             {
-                if (threads[i].Title.Length > 60)
+                if (threads[i].Title.Length > 20)
                 {
                     var summary = await _chatService.SummarizeAsync(threads[i].Title);
                     threads[i].Title = summary;

--- a/ChatApp/Services/BlobChatHistoryService.cs
+++ b/ChatApp/Services/BlobChatHistoryService.cs
@@ -9,6 +9,7 @@ namespace ChatApp.Services
     {
         private readonly BlobContainerClient _container;
         private readonly AzureOpenAIChatService _chatService;
+        private const int MaxTitleLength = 20;
 
         public BlobChatHistoryService(IConfiguration config, AzureOpenAIChatService chatService)
         {
@@ -51,7 +52,7 @@ namespace ChatApp.Services
             bool changed = false;
             for (int i = 0; i < threads.Count; i++)
             {
-                if (threads[i].Title.Length > 20)
+                if (threads[i].Title.Length > MaxTitleLength)
                 {
                     var summary = await _chatService.SummarizeAsync(threads[i].Title);
                     threads[i].Title = summary;


### PR DESCRIPTION
## Summary
- create a SummarizeAsync helper in `AzureOpenAIChatService`
- use the summarizer when creating chat threads
- shorten existing long thread titles on first load

## Testing
- `dotnet restore ChatApp/ChatApp.csproj`
- `dotnet build ChatApp/ChatApp.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68489e3b5d70832fab8ef31e8c4ec901