### PR TITLE
Add DeepSeek-R1 and Azure AI Foundry support

### DIFF
--- a/ChatApp/Components/Pages/Chat.razor
+++ b/ChatApp/Components/Pages/Chat.razor
@@ -2,7 +2,9 @@
 @page "/chat/{ThreadId?}"
 @rendermode InteractiveServer
 @attribute [Authorize]
-@inject AzureOpenAIChatService ChatService
+@inject AzureOpenAIChatService OpenAIChatService
+@inject AzureFoundryChatService FoundryChatService
+@inject IConfiguration Configuration
 @inject BlobChatHistoryService HistoryService
 @inject NavigationManager Navigation
 @inject AuthenticationStateProvider AuthenticationStateProvider
@@ -41,12 +43,18 @@
     private List<ChatMessage> Messages = new();
     private string UserMessage = string.Empty;
     private string SelectedModel = "gpt-4o";
-    private string[] Models = ["gpt-35-turbo", "gpt-4o","o4-mini"];
+    private Dictionary<string, string> ModelServiceMap = new();
+    private IEnumerable<string> Models => ModelServiceMap.Keys;
     private string? UserId;
     private bool IsAwaitingReply = false;
 
     protected override async Task OnInitializedAsync()
     {
+        ModelServiceMap = Configuration.GetSection("ModelServiceMap").Get<Dictionary<string, string>>() ?? new();
+        if (ModelServiceMap.Count > 0)
+        {
+            SelectedModel = ModelServiceMap.Keys.First();
+        }
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         UserId = authState.User?.Identity?.Name ?? "anonymous";
         if (!string.IsNullOrEmpty(ThreadId) && ThreadId != "new")
@@ -67,7 +75,16 @@
             ThreadId = await HistoryService.CreateThreadAsync(UserId, UserMessage);
         }
 
-        var reply = await ChatService.SendMessageAsync(UserId, Messages, SelectedModel);
+        string reply;
+        var service = ModelServiceMap.TryGetValue(SelectedModel, out var svc) ? svc : "AzureOpenAI";
+        if (service == "AzureFoundry")
+        {
+            reply = await FoundryChatService.SendMessageAsync(UserId, Messages, SelectedModel);
+        }
+        else
+        {
+            reply = await OpenAIChatService.SendMessageAsync(UserId, Messages, SelectedModel);
+        }
         Messages.Add(new ChatMessage { Role = "assistant", Content = reply });
         UserMessage = string.Empty;
         IsAwaitingReply = false;

--- a/ChatApp/Program.cs
+++ b/ChatApp/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddAuthorization();
 builder.Services.AddHttpClient();
 
 builder.Services.AddSingleton<AzureOpenAIChatService>();
+builder.Services.AddSingleton<AzureFoundryChatService>();
 builder.Services.AddSingleton<BlobChatHistoryService>();
 
 var app = builder.Build();

--- a/ChatApp/Services/AzureFoundryChatService.cs
+++ b/ChatApp/Services/AzureFoundryChatService.cs
@@ -1,0 +1,55 @@
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using ChatApp.Models;
+using Azure.Identity;
+using Azure.Core;
+
+namespace ChatApp.Services
+{
+    public class AzureFoundryChatService
+    {
+        private readonly HttpClient _http;
+        private readonly string _endpoint;
+        private readonly string? _key;
+        private readonly bool _useManagedIdentity;
+        private readonly TokenCredential _credential;
+        private const string ApiVersion = "2024-05-01-preview";
+
+        public AzureFoundryChatService(IConfiguration config, IHttpClientFactory factory)
+        {
+            _endpoint = config["AzureFoundry:Endpoint"] ?? throw new ArgumentNullException("AzureFoundry:Endpoint");
+            _key = config["AzureFoundry:Key"];
+            _useManagedIdentity = string.IsNullOrEmpty(_key) || bool.TryParse(config["AzureFoundry:UseManagedIdentity"], out var useMi) && useMi;
+            _credential = new DefaultAzureCredential();
+            _http = factory.CreateClient();
+        }
+
+        public async Task<string> SendMessageAsync(string userId, List<ChatMessage> messages, string deployment)
+        {
+            var url = $"{_endpoint}/openai/deployments/{deployment}/chat/completions?api-version={ApiVersion}";
+            using var request = new HttpRequestMessage(HttpMethod.Post, url);
+            if (_useManagedIdentity)
+            {
+                var token = await _credential.GetTokenAsync(new TokenRequestContext(new[] { "https://cognitiveservices.azure.com/.default" }), CancellationToken.None);
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+            }
+            else if (!string.IsNullOrEmpty(_key))
+            {
+                request.Headers.Add("api-key", _key);
+            }
+            var payload = new
+            {
+                messages = messages.Select(m => new { role = m.Role, content = m.Content }).ToList()
+            };
+            request.Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            using var response = await _http.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+            using var stream = await response.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+            var reply = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+            return reply ?? string.Empty;
+        }
+    }
+}

--- a/ChatApp/appsettings.Development.json
+++ b/ChatApp/appsettings.Development.json
@@ -18,6 +18,17 @@
     "UseManagedIdentity": false,
     "Deployment": "gpt-35-turbo"
   },
+  "AzureFoundry": {
+    "Endpoint": "https://YOUR_FOUNDRY_RESOURCE.openai.azure.com/",
+    "Key": "YOUR_KEY",
+    "UseManagedIdentity": false
+  },
+  "ModelServiceMap": {
+    "gpt-35-turbo": "AzureOpenAI",
+    "gpt-4o": "AzureOpenAI",
+    "o4-mini": "AzureOpenAI",
+    "deepseek-r1": "AzureFoundry"
+  },
   "BlobStorage": {
     "ConnectionString": "YOUR_BLOB_CONNECTION_STRING",
     "Container": "chat-history",

--- a/ChatApp/appsettings.json
+++ b/ChatApp/appsettings.json
@@ -20,6 +20,17 @@
     "UseManagedIdentity": false,
     "Deployment": "gpt-35-turbo"
   },
+  "AzureFoundry": {
+    "Endpoint": "https://YOUR_FOUNDRY_RESOURCE.openai.azure.com/",
+    "Key": "YOUR_KEY",
+    "UseManagedIdentity": false
+  },
+  "ModelServiceMap": {
+    "gpt-35-turbo": "AzureOpenAI",
+    "gpt-4o": "AzureOpenAI",
+    "o4-mini": "AzureOpenAI",
+    "deepseek-r1": "AzureFoundry"
+  },
   "BlobStorage": {
     "ConnectionString": "YOUR_BLOB_CONNECTION_STRING",
     "Container": "chat-history",

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ChatApp
 
 This sample demonstrates a simple ChatGPT-like interface built with **Blazor Server**.
-It authenticates users with **Microsoft Entra ID** and sends prompts to **Azure OpenAI**.
+It authenticates users with **Microsoft Entra ID** and sends prompts to **Azure OpenAI** or **Azure AI Foundry**.
 Each user's conversation history is stored in **Azure Blob Storage**.
 
 ## Running the application
 
-1. Update `appsettings.json` with your Azure AD, Azure OpenAI and Blob Storage settings. When deploying to Azure App Service you can use the app's managed identity by leaving `AzureOpenAI:Key` and `BlobStorage:ConnectionString` empty and setting `AzureOpenAI:UseManagedIdentity` and `BlobStorage:UseManagedIdentity` to `true`. For Blob Storage also provide `BlobStorage:AccountName` with your storage account name.
+1. Update `appsettings.json` with your Azure AD, Azure OpenAI, Azure AI Foundry, `ModelServiceMap` and Blob Storage settings. `ModelServiceMap` defines which service handles each model name. When deploying to Azure App Service you can use the app's managed identity by leaving `AzureOpenAI:Key`, `AzureFoundry:Key` and `BlobStorage:ConnectionString` empty and setting `AzureOpenAI:UseManagedIdentity`, `AzureFoundry:UseManagedIdentity` and `BlobStorage:UseManagedIdentity` to `true`. For Blob Storage also provide `BlobStorage:AccountName` with your storage account name.
 2. Restore and build the project:
    ```bash
    dotnet restore


### PR DESCRIPTION
## Summary
- introduce `AzureFoundryChatService` for Azure AI Foundry
- register the new service
- allow selecting `deepseek-r1` model in the chat UI
- add Azure Foundry configuration samples
- update README for Foundry settings
- generalize model routing via configuration map

## Testing
- `dotnet restore ChatApp`
- `dotnet build ChatApp -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68579e45a934832f8566f202ac49b0dc