### PR TITLE
Preserve model choice and support Shift+Enter

### DIFF
--- a/ChatApp/Components/Pages/Chat.razor
+++ b/ChatApp/Components/Pages/Chat.razor
@@ -62,9 +62,11 @@
         IsAwaitingReply = true;
         StateHasChanged();
 
+        var isNewThread = false;
         if (string.IsNullOrEmpty(ThreadId) || ThreadId == "new")
         {
             ThreadId = await HistoryService.CreateThreadAsync(UserId, UserMessage);
+            isNewThread = true;
         }
 
         var reply = await ChatService.SendMessageAsync(UserId, Messages, SelectedModel);
@@ -74,13 +76,16 @@
         if (ThreadId is not null)
         {
             await HistoryService.SaveHistoryAsync(UserId, ThreadId, Messages);
-            Navigation.NavigateTo($"/chat/{ThreadId}", forceLoad: true);
+            if (isNewThread)
+            {
+                Navigation.NavigateTo($"/chat/{ThreadId}", replace: true);
+            }
         }
     }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Enter" && !e.CtrlKey)
+        if (e.Key == "Enter" && !e.ShiftKey && !e.AltKey && !e.CtrlKey)
         {
             await SendMessage();
         }


### PR DESCRIPTION
## Summary
- Keep selected model when sending messages by avoiding unnecessary page reload
- Allow Shift+Enter in the chat input to insert a newline

## Testing
- `dotnet build ChatApp/ChatApp.csproj`


------
https://chatgpt.com/codex/tasks/task_e_6897bdbc0d94832fb42905b4193c76b9