### PR TITLE
Fix existing thread not loading on navigation

### DIFF
--- a/ChatApp/Components/Pages/Chat.razor
+++ b/ChatApp/Components/Pages/Chat.razor
@@ -49,9 +49,17 @@
     {
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         UserId = authState.User?.Identity?.Name ?? "anonymous";
-        if (!string.IsNullOrEmpty(ThreadId) && ThreadId != "new")
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!string.IsNullOrEmpty(ThreadId) && ThreadId != "new" && UserId is not null)
         {
             Messages = await HistoryService.LoadHistoryAsync(UserId, ThreadId);
+        }
+        else
+        {
+            Messages = new();
         }
     }
 


### PR DESCRIPTION
## Summary
- Reload chat history whenever a different thread is selected

## Testing
- `dotnet build ChatApp`


------
https://chatgpt.com/codex/tasks/task_e_6897c27a66e8832fa0f85111ebd87de6