### PR TITLE
Enable streaming responses for Azure chat services

### DIFF
--- a/ChatApp/Components/Pages/Chat.razor
+++ b/ChatApp/Components/Pages/Chat.razor
@@ -85,17 +85,26 @@
             isNewThread = true;
         }
 
-        string reply;
         var service = ModelServiceMap.TryGetValue(SelectedModel, out var svc) ? svc : "AzureOpenAI";
+        var messagesToSend = Messages.ToList();
+        var assistantMessage = new ChatMessage { Role = "assistant", Content = string.Empty };
+        Messages.Add(assistantMessage);
         if (service == "AzureFoundry")
         {
-            reply = await FoundryChatService.SendMessageAsync(UserId, Messages, SelectedModel);
+            await foreach (var token in FoundryChatService.SendMessageAsync(UserId, messagesToSend, SelectedModel))
+            {
+                assistantMessage.Content += token;
+                StateHasChanged();
+            }
         }
         else
         {
-            reply = await OpenAIChatService.SendMessageAsync(UserId, Messages, SelectedModel);
+            await foreach (var token in OpenAIChatService.SendMessageAsync(UserId, messagesToSend, SelectedModel))
+            {
+                assistantMessage.Content += token;
+                StateHasChanged();
+            }
         }
-        Messages.Add(new ChatMessage { Role = "assistant", Content = reply });
         UserMessage = string.Empty;
         IsAwaitingReply = false;
         if (ThreadId is not null)

--- a/ChatApp/Components/_Imports.razor
+++ b/ChatApp/Components/_Imports.razor
@@ -12,3 +12,4 @@
 @using ChatApp.Models
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Authorization
+@using System.Linq


### PR DESCRIPTION
## Summary
- stream responses from Azure OpenAI by parsing server-sent events
- stream responses from Azure AI Foundry using `CompleteStreamingAsync`
- update chat page to show assistant messages incrementally

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6898f97f455c832fa8853b4762149523